### PR TITLE
Fix simple animation package issue

### DIFF
--- a/lib/src/bubble_animation.dart
+++ b/lib/src/bubble_animation.dart
@@ -38,6 +38,17 @@ class BubbleAnimation {
       -0.2,
     );
 
+    duration = bubbleSpeed +
+        Duration(
+          milliseconds: randomValue.nextInt(6000),
+        );
+
+    size = 0.2 + randomValue.nextDouble() * 0.4;
+
+    startTime = Duration(
+      milliseconds: DateTime.now().millisecondsSinceEpoch,
+    );
+
     tween = MovieTween()
       ..tween(
         OffsetProps.x,
@@ -53,17 +64,6 @@ class BubbleAnimation {
           end: endPosition.dy,
         ),
       );
-
-    duration = bubbleSpeed +
-        Duration(
-          milliseconds: randomValue.nextInt(6000),
-        );
-
-    startTime = Duration(
-      milliseconds: DateTime.now().millisecondsSinceEpoch,
-    );
-
-    size = 0.2 + randomValue.nextDouble() * 0.4;
   }
 
   /// Shuffles the position of bubbles around the screen.

--- a/lib/src/bubble_animation.dart
+++ b/lib/src/bubble_animation.dart
@@ -56,6 +56,7 @@ class BubbleAnimation {
           begin: startPosition.dx,
           end: endPosition.dx,
         ),
+        duration: duration,
       )
       ..tween(
         OffsetProps.y,
@@ -63,6 +64,7 @@ class BubbleAnimation {
           begin: startPosition.dy,
           end: endPosition.dy,
         ),
+        duration: duration,
       );
   }
 

--- a/lib/src/bubbles.dart
+++ b/lib/src/bubbles.dart
@@ -148,8 +148,12 @@ class _FloatingBubblesState extends State<FloatingBubbles> {
     return widget.duration != null && widget.duration == 0
         ? LoopAnimationBuilder(
             tween: ConstantTween(1),
-            duration: Duration(seconds: widget.duration!),
-            builder: (context, child, value) {
+            // In previous versions of the package, the duration field defaulted
+            // to 1 second, but it now is mandatory.
+            // Since we were not using it before, we are passing it the previously
+            // used default value.
+            duration: Duration(seconds: 1),
+            builder: (context, value, child) {
               _simulateBubbles();
               return paintBubbles(
                 bubbles: BubblePainter(


### PR DESCRIPTION
Changes in this PR:
- After reading the migration kit again, I decided to just use what was previously the default value for the duration field of the LoopAnimation, which is `Duration(seconds: 1)`. 

- I misunderstood the migration kit on the MovieTween and got mixed up when replacing the MultiTween with a MovieTween. If we are using tween without a scene, then an exception will be thrown asking for values for 2 of these properties : `begin`, `end`, `duration`, or only `duration`, assuming `begin` is `Duration.zero`. Good to remember!
This is now solved by passing it a duration, and I've verified that it works properly in the example, as shown below.

Uploading Screen Recording 2022-08-24 at 15.21.56.mov…